### PR TITLE
Bring CDU back to life, and make CDU and Switches onto MP

### DIFF
--- a/Models/followmeEV.xml
+++ b/Models/followmeEV.xml
@@ -985,10 +985,10 @@
     </condition>
     <path>Aircraft/followme_e-tron/Models/Instruments/CDU/boeing.xml</path>
     <offsets>
-        <x-m>1.65</x-m>
-        <y-m>-0.00</y-m>
-        <z-m>0.70</z-m>
-        <pitch-deg>-87</pitch-deg>
+         <x-m>1.35</x-m>
+        <y-m>0.25</y-m>
+        <z-m>0.9</z-m>
+        <pitch-deg>-4</pitch-deg>
     </offsets>
 </model>
 <!-- Accelerator -->

--- a/Models/followmeEV.xml
+++ b/Models/followmeEV.xml
@@ -914,7 +914,7 @@
 <model>
     <condition>
 		<equals>
-			<property>systems/instruments/enable_switches</property>
+			<property>sim/multiplay/generic/int[14]</property>
 			<value>1</value>
 		</equals>
     </condition>
@@ -930,7 +930,7 @@
 <model>
     <condition>
 		<equals>
-			<property>systems/instruments/enable_switches</property>
+			<property>sim/multiplay/generic/int[14]</property>
 			<value>1</value>
 		</equals>
     </condition>
@@ -946,7 +946,7 @@
 <model>
     <condition>
 		<equals>
-			<property>systems/instruments/enable_switches</property>
+			<property>sim/multiplay/generic/int[14]</property>
 			<value>1</value>
 		</equals>
     </condition>
@@ -962,7 +962,7 @@
 <model>
     <condition>
 		<equals>
-			<property>systems/instruments/enable_switches</property>
+			<property>sim/multiplay/generic/int[14]</property>
 			<value>1</value>
 		</equals>
     </condition>

--- a/Models/followmeEV.xml
+++ b/Models/followmeEV.xml
@@ -979,7 +979,7 @@
 <model>
     <condition>
 		<equals>
-			<property>systems/instruments/enable_cdu</property>
+			<property>sim/multiplay/generic/int[13]</property>
 			<value>1</value>
 		</equals>
     </condition>

--- a/Models/followmeEV.xml
+++ b/Models/followmeEV.xml
@@ -914,7 +914,7 @@
 <model>
     <condition>
 		<equals>
-			<property>sim/multiplay/generic/int[14]</property>
+			<property>sim/multiplay/generic/int[15]</property>
 			<value>1</value>
 		</equals>
     </condition>
@@ -930,7 +930,7 @@
 <model>
     <condition>
 		<equals>
-			<property>sim/multiplay/generic/int[14]</property>
+			<property>sim/multiplay/generic/int[15]</property>
 			<value>1</value>
 		</equals>
     </condition>
@@ -946,7 +946,7 @@
 <model>
     <condition>
 		<equals>
-			<property>sim/multiplay/generic/int[14]</property>
+			<property>sim/multiplay/generic/int[15]</property>
 			<value>1</value>
 		</equals>
     </condition>
@@ -962,7 +962,7 @@
 <model>
     <condition>
 		<equals>
-			<property>sim/multiplay/generic/int[14]</property>
+			<property>sim/multiplay/generic/int[15]</property>
 			<value>1</value>
 		</equals>
     </condition>
@@ -979,7 +979,7 @@
 <model>
     <condition>
 		<equals>
-			<property>sim/multiplay/generic/int[13]</property>
+			<property>sim/multiplay/generic/int[14]</property>
 			<value>1</value>
 		</equals>
     </condition>

--- a/followme_e-tron-set.xml
+++ b/followme_e-tron-set.xml
@@ -500,6 +500,8 @@
         <int n="11" alias="/controls/direction"/>
         <int n="12" alias="/systems/codriver-enable"/>
         <int n="13" alias="/interior/enable_mug"/>
+	<int n="14" alias="systems/instruments/enable_cdu"/>
+	<int n="15" alias="systems/instruments/enable_switches"/>
 
         <float n="0" alias="/controls/doors/rearright/position-norm"/>
         <float n="1" alias="/controls/doors/rearleft/position-norm"/>

--- a/gui/dialogs/vehicle-dialog.xml
+++ b/gui/dialogs/vehicle-dialog.xml
@@ -426,8 +426,7 @@
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
-            <!-- Disable CDU for now, need reposition -->
-	    <!-- 
+      
 	    <checkbox>
                 <halign>left</halign>
                 <label>  Enable CDU</label>
@@ -437,7 +436,7 @@
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
-	    -->
+	  
 	    <checkbox>
                 <halign>left</halign>
                 <label>  Enable Mug</label>

--- a/gui/dialogs/vehicle-dialog.xml
+++ b/gui/dialogs/vehicle-dialog.xml
@@ -420,7 +420,7 @@
             <checkbox>
                 <halign>left</halign>
                 <label>  Enable Switches</label>
-                <property>systems/instruments/enable_switches</property>
+                <property>sim/multiplay/generic/int[15]</property>
                 <live>true</live>
                 <binding>
                     <command>dialog-apply</command>
@@ -430,7 +430,7 @@
 	    <checkbox>
                 <halign>left</halign>
                 <label>  Enable CDU</label>
-                <property>systems/instruments/enable_cdu</property>
+                <property>sim/multiplay/generic/int[14]</property>
                 <live>true</live>
                 <binding>
                     <command>dialog-apply</command>


### PR DESCRIPTION
Hi Sidi,
Things done:
Enabled the CDU, repositioned it to the copilot side
Yesterday I had so much fun in MP that I decided to put the Enable CDU and Enable Switches into MP Generic Int properties.
Tutorial will go on next next pull.
哈哈哈哈哈哈哈哈
Best regards,
Mars.